### PR TITLE
Use quarkus-bom instead of quarkus-universe-bom from 1.11.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,7 @@
     <byteman.version>4.0.14</byteman.version>
     <jacoco.version>0.8.4</jacoco.version>
     <plugin.surefire.version>2.22.1</plugin.surefire.version>
-    <junit.report.dir>${project.build.directory}/surefire-reports</junit.report.dir>
-    <skipSurefire>false</skipSurefire>
-    <test-forkCount>1C</test-forkCount>
-    <test-redirectOutput>true</test-redirectOutput>
+    <skipTests>false</skipTests>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -43,7 +40,7 @@
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-universe-bom</artifactId>
+        <artifactId>quarkus-bom</artifactId>
         <version>${quarkus.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -308,12 +305,8 @@
         <version>${plugin.surefire.version}</version>
         <configuration>
           <skipTests>${skipTests}</skipTests>
-          <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
-          <forkCount>${test-forkCount}</forkCount>
-          <reportsDirectory>${junit.report.dir}</reportsDirectory>
           <!-- TODO: As jacoco always crashed the @QuarkusTest ut cases, removed ${surefireArgLine} here. Will add it back to enable jacoco test coverage support when find solution -->
           <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
-          <!-- To support junit5 -->
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>

--- a/src/test/java/org/commonjava/indy/service/repository/jaxrs/RepositoryAdminResourcesTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/jaxrs/RepositoryAdminResourcesTest.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.service.repository.jaxrs;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
@@ -38,6 +39,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
+@Tag( "integration" )
 public class RepositoryAdminResourcesTest
 {
     @Test

--- a/src/test/java/org/commonjava/indy/service/repository/jaxrs/RepositoryQueryResourcesTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/jaxrs/RepositoryQueryResourcesTest.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.service.repository.jaxrs;
 
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
@@ -25,6 +26,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
+@Tag( "integration" )
 public class RepositoryQueryResourcesTest
 {
     @Test


### PR DESCRIPTION
  And:
  * Add integration tag for @QuarkusTest
  * Remove some useless surefire plugin configuration