### PR TITLE
Fix: Upgrade to use quarkus 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ target
 
 
 *.dat
+log/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                 expression { env.CHANGE_ID != null } // Pull request
             }
             steps {
-                sh '${M2_HOME}/bin/mvn -B -V clean verify sonar:sonar -Prun-its'
+                sh '${M2_HOME}/bin/mvn -B -V clean verify sonar:sonar -Prun-its -Dquarkus.naming.enable-jndi=true'
             }
         }
         stage('Load OCP Mappings') {

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>service-parent</artifactId>
-    <version>1</version>
+    <version>2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.commonjava.indy.service</groupId>

--- a/src/test/java/org/commonjava/indy/service/repository/data/infinispan/cpool/ContextBindAndLookupTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/data/infinispan/cpool/ContextBindAndLookupTest.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.service.repository.data.infinispan.cpool;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.naming.InitialContext;
@@ -27,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ContextBindAndLookupTest
 {
-    @Test
+    @Test()
     public void bindAndLookup()
             throws NamingException
     {
@@ -35,6 +36,7 @@ public class ContextBindAndLookupTest
         String val = "BAR";
 
         Properties properties = System.getProperties();
+        properties.setProperty( "quarkus.naming.enable-jndi", "true" );
         properties.setProperty( INITIAL_CONTEXT_FACTORY, CPInitialContextFactory.class.getName() );
         System.setProperties( properties );
 

--- a/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/AbstractStoreEventTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/AbstractStoreEventTest.java
@@ -16,8 +16,8 @@
 package org.commonjava.indy.service.repository.ftests.admin.event;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
-import io.smallrye.reactive.messaging.connectors.InMemorySink;
+import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
 import org.commonjava.event.store.IndyStoreEvent;
 import org.commonjava.indy.service.repository.change.event.kafka.KafkaEventUtils;
 import org.commonjava.indy.service.repository.ftests.AbstractStoreManagementTest;

--- a/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/CreateAndUpdateRepoWithEventTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/CreateAndUpdateRepoWithEventTest.java
@@ -17,7 +17,7 @@ package org.commonjava.indy.service.repository.ftests.admin.event;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.smallrye.reactive.messaging.connectors.InMemorySink;
+import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
 import org.commonjava.event.store.EventStoreKey;
 import org.commonjava.event.store.IndyStoreEvent;
 import org.commonjava.event.store.StoreEventType;

--- a/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/CreateRepoWithEventTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/CreateRepoWithEventTest.java
@@ -17,7 +17,7 @@ package org.commonjava.indy.service.repository.ftests.admin.event;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.smallrye.reactive.messaging.connectors.InMemorySink;
+import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
 import org.commonjava.event.store.IndyStoreEvent;
 import org.commonjava.event.store.StoreEventType;
 import org.commonjava.event.store.StorePostUpdateEvent;

--- a/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/CreateThenDeleteRepoWithEventTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/ftests/admin/event/CreateThenDeleteRepoWithEventTest.java
@@ -17,7 +17,7 @@ package org.commonjava.indy.service.repository.ftests.admin.event;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.smallrye.reactive.messaging.connectors.InMemorySink;
+import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
 import org.commonjava.event.store.IndyStoreEvent;
 import org.commonjava.event.store.StoreEventType;
 import org.commonjava.event.store.StorePostDeleteEvent;

--- a/src/test/java/org/commonjava/indy/service/repository/testutil/KafkaTestResourceLifecycleManager.java
+++ b/src/test/java/org/commonjava/indy/service/repository/testutil/KafkaTestResourceLifecycleManager.java
@@ -16,7 +16,7 @@
 package org.commonjava.indy.service.repository.testutil;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
 
 import java.util.Map;
 


### PR DESCRIPTION
   We need to support otel plugin, which is enabled in quarkus 2.x