### PR TITLE
Revert 7f482a8: Remove the cache of Store Query result

### DIFF
--- a/src/main/java/org/commonjava/indy/service/repository/data/AbstractStoreDataManager.java
+++ b/src/main/java/org/commonjava/indy/service/repository/data/AbstractStoreDataManager.java
@@ -83,7 +83,7 @@ public abstract class AbstractStoreDataManager
     @Override
     public ArtifactStoreQuery<ArtifactStore> query()
     {
-        return new DefaultArtifactStoreQuery<>( this, getCacheProducer() );
+        return new DefaultArtifactStoreQuery<>( this );
     }
 
     protected abstract Optional<ArtifactStore> getArtifactStoreInternal( final StoreKey key );

--- a/src/main/java/org/commonjava/indy/service/repository/data/DefaultArtifactStoreQuery.java
+++ b/src/main/java/org/commonjava/indy/service/repository/data/DefaultArtifactStoreQuery.java
@@ -16,8 +16,6 @@
 package org.commonjava.indy.service.repository.data;
 
 import org.apache.commons.lang3.StringUtils;
-import org.commonjava.indy.service.repository.data.infinispan.BasicCacheHandle;
-import org.commonjava.indy.service.repository.data.infinispan.CacheProducer;
 import org.commonjava.indy.service.repository.exception.IndyDataException;
 import org.commonjava.indy.service.repository.model.ArtifactStore;
 import org.commonjava.indy.service.repository.model.Group;
@@ -40,7 +38,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -68,8 +65,6 @@ import static org.commonjava.indy.service.repository.model.StoreType.group;
 public class DefaultArtifactStoreQuery<T extends ArtifactStore>
         implements ArtifactStoreQuery<T>
 {
-    private final Integer STORE_QUERY_EXPIRATION_IN_MINS = 15;
-
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     private StoreDataManager dataManager;
@@ -80,13 +75,20 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
 
     private Boolean enabled;
 
-    private final CacheProducer cacheProducer;
+//    private final Integer STORE_QUERY_EXPIRATION_IN_MINS = 15;
+//    private final CacheProducer cacheProducer;
 
-    public DefaultArtifactStoreQuery( StoreDataManager dataManager, CacheProducer cacheProducer )
+//    public DefaultArtifactStoreQuery( StoreDataManager dataManager, CacheProducer cacheProducer )
+//    {
+//        logger.debug( "CREATE new default store query with data manager only" );
+//        this.dataManager = dataManager;
+//        this.cacheProducer = cacheProducer;
+//    }
+
+    public DefaultArtifactStoreQuery( StoreDataManager dataManager )
     {
         logger.debug( "CREATE new default store query with data manager only" );
         this.dataManager = dataManager;
-        this.cacheProducer = cacheProducer;
     }
 
     @Override
@@ -407,17 +409,18 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
             }
             return null;
         };
-        final String queryKey =
-                String.format( "%s:%s:%s:%s", packageType, groupName, enabled, "orderedConcreteStoresInGroup" );
-        Collection<? extends ArtifactStore> stores;
-        try
-        {
-            stores = computeIfAbsent( queryKey, storeProvider, STORE_QUERY_EXPIRATION_IN_MINS, Boolean.FALSE );
-        }
-        catch ( IllegalStateException e )
-        {
-            stores = storeProvider.get();
-        }
+
+        Collection<? extends ArtifactStore> stores = storeProvider.get();
+//        final String queryKey =
+//                String.format( "%s:%s:%s:%s", packageType, groupName, enabled, "orderedConcreteStoresInGroup" );
+//        try
+//        {
+//            stores = computeIfAbsent( queryKey, storeProvider, STORE_QUERY_EXPIRATION_IN_MINS, Boolean.FALSE );
+//        }
+//        catch ( IllegalStateException e )
+//        {
+//            stores = storeProvider.get();
+//        }
         if ( holder.get() != null )
         {
             logger.error( holder.get().getMessage() );
@@ -469,16 +472,17 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
             }
             return null;
         };
-        final Set<StoreKey> queryKeys = new HashSet<>( keys );
-        Collection<? extends ArtifactStore> stores;
-        try
-        {
-            stores = computeIfAbsent( queryKeys, storeProvider, STORE_QUERY_EXPIRATION_IN_MINS, Boolean.FALSE );
-        }
-        catch ( IllegalStateException e )
-        {
-            stores = storeProvider.get();
-        }
+
+        Collection<? extends ArtifactStore> stores = storeProvider.get();
+//        final Set<StoreKey> queryKeys = new HashSet<>( keys );
+//        try
+//        {
+//            stores = computeIfAbsent( queryKeys, storeProvider, STORE_QUERY_EXPIRATION_IN_MINS, Boolean.FALSE );
+//        }
+//        catch ( IllegalStateException e )
+//        {
+//            stores = storeProvider.get();
+//        }
         if ( eHolder.get() != null )
         {
             logger.error( eHolder.get().getMessage() );
@@ -674,40 +678,40 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
     }
 
     //TODO: As here introduced a new cache, we need to think about update this cache when store event happen.
-    private Collection<? extends ArtifactStore> computeIfAbsent( Object key,
-                                                                 Supplier<Collection<? extends ArtifactStore>> storeProvider,
-                                                                 int expirationMins, boolean forceQuery )
-    {
-        if ( cacheProducer == null )
-        {
-            throw new IllegalStateException( "No cache producer, so need to bypass caching" );
-        }
-        final String ARTIFACT_STORE_QUERY = "artifact-store-query";
-        logger.debug( "computeIfAbsent, cache: {}, key: {}", ARTIFACT_STORE_QUERY, key );
-
-        BasicCacheHandle<Object, Collection<? extends ArtifactStore>> cache =
-                cacheProducer.getCache( ARTIFACT_STORE_QUERY );
-        Collection<? extends ArtifactStore> stores = cache.get( key );
-        if ( stores == null || forceQuery )
-        {
-            logger.trace( "Entry not found, run put, expirationMins: {}", expirationMins );
-
-            stores = storeProvider.get();
-
-            if ( stores != null )
-            {
-                if ( expirationMins > 0 )
-                {
-                    cache.put( key, stores, expirationMins, TimeUnit.MINUTES );
-                }
-                else
-                {
-                    cache.put( key, stores );
-                }
-            }
-        }
-
-        logger.trace( "Return value, cache: {}, key: {}, ret: {}", ARTIFACT_STORE_QUERY, key, stores );
-        return stores;
-    }
+//    private Collection<? extends ArtifactStore> computeIfAbsent( Object key,
+//                                                                 Supplier<Collection<? extends ArtifactStore>> storeProvider,
+//                                                                 int expirationMins, boolean forceQuery )
+//    {
+//        if ( cacheProducer == null )
+//        {
+//            throw new IllegalStateException( "No cache producer, so need to bypass caching" );
+//        }
+//        final String ARTIFACT_STORE_QUERY = "artifact-store-query";
+//        logger.debug( "computeIfAbsent, cache: {}, key: {}", ARTIFACT_STORE_QUERY, key );
+//
+//        BasicCacheHandle<Object, Collection<? extends ArtifactStore>> cache =
+//                cacheProducer.getCache( ARTIFACT_STORE_QUERY );
+//        Collection<? extends ArtifactStore> stores = cache.get( key );
+//        if ( stores == null || forceQuery )
+//        {
+//            logger.trace( "Entry not found, run put, expirationMins: {}", expirationMins );
+//
+//            stores = storeProvider.get();
+//
+//            if ( stores != null )
+//            {
+//                if ( expirationMins > 0 )
+//                {
+//                    cache.put( key, stores, expirationMins, TimeUnit.MINUTES );
+//                }
+//                else
+//                {
+//                    cache.put( key, stores );
+//                }
+//            }
+//        }
+//
+//        logger.trace( "Return value, cache: {}, key: {}, ret: {}", ARTIFACT_STORE_QUERY, key, stores );
+//        return stores;
+//    }
 }


### PR DESCRIPTION
  We found that this query cachhe is causing some problem with deprecated data
  in indy-monolith integration testing, so rolled back the query to none