### PR TITLE
Fix: url decoding problem for query param

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -36,8 +36,8 @@ quarkus:
 
   # Logging (disable console on prod)
   log:
-    level: INFO
-    min-level: INFO
+    level: DEBUG
+    min-level: TRACE
     category:
       "org.jboss":
         level: WARN
@@ -52,6 +52,8 @@ quarkus:
         level: WARN
       "io.netty":
         level: WARN
+      "io.grpc":
+        level: WARN
       "org.infinispan":
         level: WARN
       "io.agroal":
@@ -61,10 +63,10 @@ quarkus:
         min-level: DEBUG
     console:
       enable: true
-      level: INFO
+      level: DEBUG
     file:
       enable: true
-      level: INFO
+      level: DEBUG
       path: "log/indy-repository-service.log"
       format: "%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n"
       rotation:

--- a/src/main/java/org/commonjava/indy/service/repository/controller/QueryController.java
+++ b/src/main/java/org/commonjava/indy/service/repository/controller/QueryController.java
@@ -26,6 +26,8 @@ import org.commonjava.indy.service.repository.model.HostedRepository;
 import org.commonjava.indy.service.repository.model.RemoteRepository;
 import org.commonjava.indy.service.repository.model.StoreKey;
 import org.commonjava.indy.service.repository.model.StoreType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -48,6 +50,8 @@ import static org.commonjava.indy.service.repository.model.pkg.PackageTypeConsta
 @ApplicationScoped
 public class QueryController
 {
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
     @Inject
     StoreDataManager storeManager;
 
@@ -152,6 +156,7 @@ public class QueryController
     {
         final boolean isEnabled =
                 enabled == null || enabled.equalsIgnoreCase( "yes" ) || Boolean.parseBoolean( enabled );
+        logger.debug( "Searching Concrete repos in group {} with enabled {}", storeKey, isEnabled );
         return generateQueryResult( () -> {
             final StoreKey key = validateStoreKey( storeKey );
             if ( key.getType() != StoreType.group )

--- a/src/main/java/org/commonjava/indy/service/repository/jaxrs/RepositoryQueryResources.java
+++ b/src/main/java/org/commonjava/indy/service/repository/jaxrs/RepositoryQueryResources.java
@@ -182,7 +182,7 @@ public class RepositoryQueryResources
             @Parameter( description = "If the repositories retrieved are enabled, default is true if not specified",
                         example = "true" ) @QueryParam( "enabled" ) final String enabled )
     {
-        final String storeKeyDecoded = UrlUtils.uriDecode( storeKey, defaultCharset() );
+        final String storeKeyDecoded = UrlUtils.uriDecode( storeKey );
         return generateStoreListingResponse( () -> queryController.getGroupsContaining( storeKeyDecoded, enabled ) );
     }
 
@@ -201,7 +201,7 @@ public class RepositoryQueryResources
                         example = "true" ) @QueryParam( "enabled" ) final String enabled )
     {
         logger.debug( "StoreKey is {}", storeKey );
-        final String storeKeyDecoded = UrlUtils.uriDecode( storeKey, defaultCharset() );
+        final String storeKeyDecoded = UrlUtils.uriDecode( storeKey );
         logger.debug( "StoreKey decoded is {}", storeKeyDecoded );
         return generateStoreListingResponse(
                 () -> queryController.getOrderedConcreteStoresInGroup( storeKeyDecoded, enabled ) );
@@ -221,7 +221,7 @@ public class RepositoryQueryResources
             @Parameter( description = "If the repositories retrieved are enabled, default is true if not specified",
                         example = "true" ) @QueryParam( "enabled" ) final String enabled )
     {
-        final String storeKeyDecoded = UrlUtils.uriDecode( storeKey, defaultCharset() );
+        final String storeKeyDecoded = UrlUtils.uriDecode( storeKey );
         return generateStoreListingResponse(
                 () -> queryController.getOrderedStoresInGroup( storeKeyDecoded, enabled ) );
     }
@@ -246,7 +246,7 @@ public class RepositoryQueryResources
             logger.error( e.getMessage(), e );
             return responseHelper.formatResponse( e );
         }
-        final String keysDecoded = UrlUtils.uriDecode( keys, defaultCharset() );
+        final String keysDecoded = UrlUtils.uriDecode( keys );
         return generateStoreListingResponse( () -> {
             String[] keysArr = keysDecoded.split( "," );
             if ( keysArr.length == 0 )

--- a/src/main/java/org/commonjava/indy/service/repository/util/UrlUtils.java
+++ b/src/main/java/org/commonjava/indy/service/repository/util/UrlUtils.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public final class UrlUtils
@@ -114,7 +115,7 @@ public final class UrlUtils
         Charset providedCharSet = charset;
         if ( providedCharSet == null )
         {
-            providedCharSet = Charset.defaultCharset();
+            providedCharSet = StandardCharsets.UTF_8;
         }
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream( length );
@@ -150,6 +151,11 @@ public final class UrlUtils
             }
         }
         return ( changed ? baos.toString( providedCharSet ) : source );
+    }
+
+    public static String uriDecode( String source )
+    {
+        return uriDecode( source, null );
     }
 
 }

--- a/src/test/java/org/commonjava/indy/service/repository/util/UrlUtilsTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/util/UrlUtilsTest.java
@@ -67,18 +67,18 @@ public class UrlUtilsTest
     @Test
     public void testDecode()
     {
-        assertThat( UrlUtils.uriDecode( "", defaultCharset() ), is( "" ) );
-        assertThat( UrlUtils.uriDecode( "foobar", defaultCharset() ), is( "foobar" ) );
-        assertThat( UrlUtils.uriDecode( "foo%20bar", defaultCharset() ), is( "foo bar" ) );
-        assertThat( UrlUtils.uriDecode( "foo%2bbar", defaultCharset() ), is( "foo+bar" ) );
-        assertThat( UrlUtils.uriDecode( "T%C5%8Dky%C5%8D", defaultCharset() ), is( "T\u014dky\u014d" ) );
-        assertThat( UrlUtils.uriDecode( "/Z%C3%BCrich", defaultCharset() ), is( "/Z\u00fcrich" ) );
-        assertThat( UrlUtils.uriDecode( "T\u014dky\u014d", defaultCharset() ), is( "T\u014dky\u014d" ) );
+        assertThat( UrlUtils.uriDecode( "" ), is( "" ) );
+        assertThat( UrlUtils.uriDecode( "foobar" ), is( "foobar" ) );
+        assertThat( UrlUtils.uriDecode( "foo%20bar" ), is( "foo bar" ) );
+        assertThat( UrlUtils.uriDecode( "foo%2bbar" ), is( "foo+bar" ) );
+        assertThat( UrlUtils.uriDecode( "T%C5%8Dky%C5%8D" ), is( "T\u014dky\u014d" ) );
+        assertThat( UrlUtils.uriDecode( "/Z%C3%BCrich" ), is( "/Z\u00fcrich" ) );
+        assertThat( UrlUtils.uriDecode( "T\u014dky\u014d" ), is( "T\u014dky\u014d" ) );
     }
 
     @Test
     public void testDecodeInvalidSequence()
     {
-        assertThrows( IllegalArgumentException.class, () -> UrlUtils.uriDecode( "foo%2", defaultCharset() ) );
+        assertThrows( IllegalArgumentException.class, () -> UrlUtils.uriDecode( "foo%2" ) );
     }
 }

--- a/src/test/java/org/commonjava/indy/service/repository/util/UrlUtilsTest.java
+++ b/src/test/java/org/commonjava/indy/service/repository/util/UrlUtilsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 
+import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Map.of;
 import static org.commonjava.indy.service.repository.util.UrlUtils.buildUrl;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -47,5 +48,37 @@ public class UrlUtilsTest
         assertThat( "https://a/b/c", is( buildUrl( "https://a", "b", "c" ) ) );
         assertThat( "ftp://a/b/c", is( buildUrl( "ftp://a", "b", "c" ) ) );
         assertThrows( MalformedURLException.class, () -> buildUrl( "rdp://a", "b", "c" ) );
+    }
+
+    @Test
+    public void testUriDecode()
+    {
+        String url =
+                "http://localhost:8080/api/admin/stores/query/concretes/inGroup?storeKey=maven:group:maven:group:builds-untested%2bshared-imports&enabled=true";
+        String decoded = UrlUtils.uriDecode( url, defaultCharset() );
+        assertThat( decoded,
+                    is( "http://localhost:8080/api/admin/stores/query/concretes/inGroup?storeKey=maven:group:maven:group:builds-untested+shared-imports&enabled=true" ) );
+        url =
+                "http://localhost:8080/api/admin/stores/query/concretes/inGroup?storeKey=maven:group:maven:group:builds-untested+shared-imports&enabled=true";
+        decoded = UrlUtils.uriDecode( url, defaultCharset() );
+        assertThat( decoded, is( url ) );
+    }
+
+    @Test
+    public void testDecode()
+    {
+        assertThat( UrlUtils.uriDecode( "", defaultCharset() ), is( "" ) );
+        assertThat( UrlUtils.uriDecode( "foobar", defaultCharset() ), is( "foobar" ) );
+        assertThat( UrlUtils.uriDecode( "foo%20bar", defaultCharset() ), is( "foo bar" ) );
+        assertThat( UrlUtils.uriDecode( "foo%2bbar", defaultCharset() ), is( "foo+bar" ) );
+        assertThat( UrlUtils.uriDecode( "T%C5%8Dky%C5%8D", defaultCharset() ), is( "T\u014dky\u014d" ) );
+        assertThat( UrlUtils.uriDecode( "/Z%C3%BCrich", defaultCharset() ), is( "/Z\u00fcrich" ) );
+        assertThat( UrlUtils.uriDecode( "T\u014dky\u014d", defaultCharset() ), is( "T\u014dky\u014d" ) );
+    }
+
+    @Test
+    public void testDecodeInvalidSequence()
+    {
+        assertThrows( IllegalArgumentException.class, () -> UrlUtils.uriDecode( "foo%2", defaultCharset() ) );
     }
 }


### PR DESCRIPTION
  We found that JAXRS has some problems to do encode/decode of query
  param, for example, if a query param contains "+", it will be
  converted to a space which is not correct. The most cause is this
  issue: https://bugs.openjdk.org/browse/JDK-8179507
  So this fix will use a SpringFramework's UrlUtils to decode these url query param
  manually.