### PR TITLE
Update indymodel.version to 1.5-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <projectEmail>https://github.com/Commonjava/indy-repository-service</projectEmail>
 
     <atlas.version>1.1.1</atlas.version>
-    <indymodel.version>1.4</indymodel.version>
+    <indymodel.version>1.5-SNAPSHOT</indymodel.version>
     <indysecurity.verison>1.1</indysecurity.verison>
 
     <cassandra.version>3.11.3</cassandra.version>


### PR DESCRIPTION
The indymodel.version to 1.5-SNAPSHOT contains the new path style base64url. Although no direct usage in repo service, update it to align with others.