### PR TITLE
Update the dep of jackson-dataformat-yaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>


### PR DESCRIPTION
The latest code with quarkus 3 reports the following error when I tried it on the new cluster, seems the version issue, let's remove the specific version here to have a try. 

`
2024-03-22 08:57:01,827 INFO [org.com.ind.ser.sec.com.SecurityConstraintProvider] (executor-thread-1) Will parse security bindings from: /<mnt path>/security-bindings.yaml.
2024-03-22 08:57:01,829 ERROR [io.und.req.io] (executor-thread-1) Exception handling request 606f412c-118d-4c49-9941-9abcc7ebb35a-14 to /api/admin/stores/maven/remote/central: java.lang.NoSuchMethodError: 'void org.yaml.snakeyaml.parser.ParserImpl.<init>(org.yaml.snakeyaml.reader.StreamReader)'
at com.fasterxml.jackson.dataformat.yaml.YAMLParser.<init>(YAMLParser.java:191)
at com.fasterxml.jackson.dataformat.yaml.YAMLFactory._createParser(YAMLFactory.java:504)
at com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser(YAMLFactory.java:406)
at com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser(YAMLFactory.java:15)
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3809)
at org.commonjava.indy.service.security.common.SecurityConstraintProvider.parseBindings(SecurityConstraintProvider.java:122)
`