### PR TITLE
Fix missing build time config

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,9 +40,13 @@ quarkus:
       enabled-in-dev-mode: false
   otel:
     enabled: true
+    traces:
+      enabled: true
+      sampler:
+        ~: traceidratio
+        arg: 1.0
   log:
     level: INFO
-    min-level: TRACE
     category:
       "org.jboss":
         level: WARN


### PR DESCRIPTION
Fix below otel and log related warns,

WARN [io.qua.run.con.ConfigRecorder] (main) Build time property cannot be changed at runtime:
- quarkus.otel.traces.sampler is set to 'traceidratio' but it is build time fixed to 'parentbased_always_on'. Did you change the property quarkus.otel.traces.sampler after building the application?
- quarkus.log.min-level is set to 'INFO' but it is build time fixed to 'TRACE'. Did you change the property quarkus.log.min-level after building the application?