### PR TITLE
Set false for build time config auth.proactive

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,8 @@ quarkus:
     read-timeout: 30m
     limits:
       max-body-size: 500m
+    auth:
+      proactive: false
   package:
     type: uber-jar
   application:


### PR DESCRIPTION
This config skip the authentication if not needed. It is build-time config.

Ref https://quarkus.io/guides/security-proactive-authentication

> Proactive authentication is enabled in Quarkus by default. It ensures that all incoming requests with credentials are authenticated, even if the target page does not require authentication. As a result, requests with invalid credentials are rejected, even if the target page is public. You can turn off this default behavior if you want to authenticate only when the target page requires it. 