### PR TITLE
Use io.opentelemetry:opentelemetry-exporter-otlp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,8 @@
       <artifactId>opentelemetry-sdk-extension-jaeger-remote-sampler</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
     </dependency>
     <!-- quarkus otel deps end -->
     <dependency>


### PR DESCRIPTION
The 'io.quarkus:quarkus-opentelemetry-exporter-otlp' is relocated. Replace it with 'io.opentelemetry:opentelemetry-exporter-otlp'.