### PR TITLE
Update Cassandra reconnect policy and default delay value

### DIFF
--- a/src/main/java/org/commonjava/indy/service/repository/data/cassandra/CassandraClient.java
+++ b/src/main/java/org/commonjava/indy/service/repository/data/cassandra/CassandraClient.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.service.repository.data.cassandra;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
 import io.quarkus.runtime.Startup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,8 @@ public class CassandraClient
         socketOptions.setReadTimeoutMillis( config.getReadTimeoutMillis() );
         Cluster.Builder builder = Cluster.builder()
                                          .withoutJMXReporting()
+                                         .withReconnectionPolicy(
+                                                 new ConstantReconnectionPolicy( config.getConstantDelayMs() ) )
                                          .withRetryPolicy( new ConfigurableRetryPolicy( config.getReadRetries(),
                                                                                         config.getWriteRetries() ) )
                                          .addContactPoint( host )

--- a/src/main/java/org/commonjava/indy/service/repository/data/cassandra/CassandraConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/repository/data/cassandra/CassandraConfiguration.java
@@ -66,6 +66,10 @@ public class CassandraConfiguration
     int writeRetries;
 
     @Inject
+    @ConfigProperty( name = "cassandra.reconnect.delay", defaultValue = "60000" )
+    long constantDelayMs;
+
+    @Inject
     @ConfigProperty( name = "cassandra.keyspace" )
     Optional<String> keyspace;
 
@@ -165,6 +169,16 @@ public class CassandraConfiguration
     public void setWriteRetries( int writeRetries )
     {
         this.writeRetries = writeRetries;
+    }
+
+    public long getConstantDelayMs()
+    {
+        return constantDelayMs;
+    }
+
+    public void setConstantDelayMs( long constantDelayMs )
+    {
+        this.constantDelayMs = constantDelayMs;
     }
 
     public String getKeyspace()


### PR DESCRIPTION
Use ConstantReconnectionPolicy instead of exponential policy, see https://issues.redhat.com/browse/MMENG-4231.