### PR TITLE
Add timeout config for httpclient

### DIFF
--- a/src/main/java/org/commonjava/indy/service/repository/config/IndyRepositoryConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/repository/config/IndyRepositoryConfiguration.java
@@ -50,6 +50,14 @@ public interface IndyRepositoryConfiguration
     @WithDefault( "false" )
     Boolean storeValidationEnabled();
 
+    @WithName( "storeValidator.req-connection-timeout" )
+    @WithDefault( "30000" )
+    Integer reqConnectionTimeout();
+
+    @WithName( "storeValidator.req-socket-timeout" )
+    @WithDefault( "30000" )
+    Integer reqSocketTimeout();
+
     @WithName( "remote.sslRequired" )
     @WithDefault( "false" )
     Boolean sslRequired();

--- a/src/main/java/org/commonjava/indy/service/repository/data/DefaultStoreValidator.java
+++ b/src/main/java/org/commonjava/indy/service/repository/data/DefaultStoreValidator.java
@@ -59,7 +59,7 @@ public class DefaultStoreValidator
     //    @Inject
     //    @WeftManaged
     //    @ExecutorConfig( named = "store-validation", threads = 2, priority = 6 )
-    private final ExecutorService executorService = Executors.newFixedThreadPool( 2 );
+    private final ExecutorService executorService = Executors.newFixedThreadPool( 8 );
 
     @Inject
     IndyRepositoryConfiguration configuration;

--- a/src/main/java/org/commonjava/indy/service/repository/data/DefaultStoreValidator.java
+++ b/src/main/java/org/commonjava/indy/service/repository/data/DefaultStoreValidator.java
@@ -190,8 +190,8 @@ public class DefaultStoreValidator
         countDownLatch.countDown();
         return executorService.submit( () -> {
             RequestConfig requestConfig = RequestConfig.custom()
-                    .setConnectTimeout( 30000 )
-                    .setSocketTimeout( 30000 )
+                    .setConnectTimeout( configuration.reqConnectionTimeout() )
+                    .setSocketTimeout( configuration.reqSocketTimeout() )
                     .build();
 
             CloseableHttpClient closeableHttpClient = HttpClientBuilder.create()
@@ -228,8 +228,8 @@ public class DefaultStoreValidator
         countDownLatch.countDown();
         return executorService.submit( () -> {
             RequestConfig requestConfig = RequestConfig.custom()
-                    .setConnectTimeout( 30000 )
-                    .setSocketTimeout( 30000 )
+                    .setConnectTimeout( configuration.reqConnectionTimeout() )
+                    .setSocketTimeout( configuration.reqSocketTimeout() )
                     .build();
 
             CloseableHttpClient closeableHttpClient = HttpClientBuilder.create()


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/MMENG-4459

For the blocked remote sites, we need to make it failure earlier rather than waiting and retrying to connect. 